### PR TITLE
Fix: No module named 'distro'

### DIFF
--- a/usr/sbin/pam-accesscontrol
+++ b/usr/sbin/pam-accesscontrol
@@ -19,8 +19,14 @@
 #    along with PAM-ACCESSCONTROL.  If not, see <http://www.gnu.org/licenses/>.
 
 import subprocess as sp
-import os, sys, re, glob, shutil, distro, socket
+import os, sys, re, glob, shutil, socket
 
+def import_or_install(distro):
+  try:
+    __import__(distro)
+  except ImportError:
+    pip.main(['install', distro])
+    
 VERSION = "v0.98 Beta"
 PATH_PAM = "/etc/pam.d/"
 


### PR DESCRIPTION
ok ?

**To reproduce exception :** 
ArchLinux Base Installation + python 3.8.1-3 + pam-accesscontrol v0.97 "Postman"
```bash
$ pam-accesscontrol pam-list

Traceback (most recent call last):
  File "pam-accesscontrol", line 22, in <module>
    import os, sys, re, glob, shutil, distro, socket
ModuleNotFoundError: No module named 'distro'
```
